### PR TITLE
fix: Ruby 4.0 support (ERB.new API change)

### DIFF
--- a/extconf.rb
+++ b/extconf.rb
@@ -31,10 +31,10 @@ headers << '#define HAVE_RUBY_RUN_NODE 1' if have_func('ruby_run_node')
 config['COMMON_HEADERS'] = ([(COMMON_HEADERS || '')]+headers).join("\n")
 
 %w[Makefile rsdl.c].each { |file|
-  file_in = ERB.new(File.read(file + '.in'), nil, '%')
+  file_in = ERB.new(File.read(file + '.in'), trim_mode: '%')
   message "creating %s\n" % file
-  open(file, 'w') do |f|
-    f.print file_in.result
+  File.open(file, 'w') do |f|
+    f.print file_in.result(binding)
   end
 }
 


### PR DESCRIPTION
## Summary

Fix `extconf.rb` to work with Ruby 4.0.

Ruby 4.0 removed:
- Positional arguments from `ERB.new` → use `trim_mode:` keyword argument
- `Kernel#open` → use `File.open`

Also pass `binding` to `ERB#result` for proper variable access.

## Changes

```diff
- file_in = ERB.new(File.read(file + '.in'), nil, '%')
+ file_in = ERB.new(File.read(file + '.in'), trim_mode: '%')
  message "creating %s\n" % file
- open(file, 'w') do |f|
-   f.print file_in.result
+ File.open(file, 'w') do |f|
+   f.print file_in.result(binding)
```

## Testing

- Ruby 4.0.2: build + run OK
- Ruby 3.3.9: backward compatible, build + run OK
